### PR TITLE
Update Typesense from 29.0 to 30.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM caddy:latest AS caddy
 COPY Caddyfile ./
 RUN caddy fmt --overwrite Caddyfile
 
-FROM typesense/typesense:29.0
+FROM typesense/typesense:30.1
 
 COPY --from=caddy /srv/Caddyfile ./
 


### PR DESCRIPTION
Updates the Typesense Docker image from `29.0` to `30.1` (latest stable).

### What changed
- `Dockerfile` line 8: `typesense/typesense:29.0` → `typesense/typesense:30.1`

### What's in 30.x
- **30.0**: MMR search diversity, global synonyms, enhanced JOINs, union search improvements, IPv6 support
- **30.1**: Bug fix for search latency metric overflow in `stats.json`

Docker image [`typesense/typesense:30.1`](https://hub.docker.com/r/typesense/typesense/tags?name=30.1) is available with multi-arch support (amd64 + arm64).