### PR TITLE
Fix remote embeddings by binding API to all interfaces

### DIFF
--- a/scripts/start_typesense.sh
+++ b/scripts/start_typesense.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec /opt/typesense-server --api-address 127.0.0.1 --api-port 8118
+exec /opt/typesense-server --api-address 0.0.0.0 --api-port 8118


### PR DESCRIPTION
## Summary
- Changes `--api-address` from `127.0.0.1` to `0.0.0.0` in `start_typesense.sh`
- Fixes remote embedding calls (OpenAI, Google, etc.) failing with empty `OpenAI API error:` when running on Railway

## Problem
When `--api-address=127.0.0.1`, Typesense routes remote embedding API calls through an internal `/proxy` endpoint. Inside Docker containers on Railway, Typesense auto-detects the container's internal network IP for its raft peering system and tries to proxy through that IP — which fails because Typesense is only listening on `127.0.0.1`.

This results in:
```
RequestMalformed: Request failed with HTTP code 400 | Server said: OpenAI API error:
```

The error message is empty because the request never reaches OpenAI — it fails at Typesense's internal proxy step.

This issue has been reported by other users as well: https://discord.com/channels/713503345364697088/1416110939106840627

## Fix
Binding to `0.0.0.0` makes Typesense listen on all interfaces, allowing the internal proxy to reach itself and complete remote embedding calls successfully.

## Testing
- Confirmed that with `127.0.0.1`, creating a collection with `openai/text-embedding-3-small` embedding fails
- Confirmed that built-in models (`ts/all-MiniLM-L12-v2`) work fine (no outbound call needed)
- The fix has been verified by other Railway users experiencing the same issue